### PR TITLE
fix: ln payinvoice & error msg

### DIFF
--- a/logic/ln-url.ts
+++ b/logic/ln-url.ts
@@ -91,7 +91,7 @@ export default class Lnurl {
   }
 
   static isLnurl(url: string): boolean {
-    return Lnurl.findlnurl(url) !== null;
+    return Lnurl.findlnurl(url) !== undefined;
   }
 
   static decipherAES(

--- a/services/lightning/lnd.ts
+++ b/services/lightning/lnd.ts
@@ -392,11 +392,14 @@ export default class LNDService implements ILightningClient {
 
     const Lightning = await this.getLightningClient();
     const response = await Lightning.sendPaymentSync(rpcPayload);
-    // Sometimes the error comes in on the response...
+
     if (response.paymentError) {
-      throw new Error(
-        `Unable to send Lightning payment: ${response.paymentError}`,
-      );
+      return {
+        ...response,
+        paymentHash: '',
+        paymentPreimage: '',
+        paymentError: `Unable to send Lightning payment: ${response.paymentError}`,
+      };
     }
 
     return {


### PR DESCRIPTION
This fixes the Lightning payments in Citadel UI, looks like this bug was introduced when I linted the files for the first time. We also return the error message as the response now. 