### PR TITLE
fix: improve passport verify checks

### DIFF
--- a/middlewares/auth.ts
+++ b/middlewares/auth.ts
@@ -33,7 +33,11 @@ const jwtOptions = await createJwtOptions();
 passport.use(
   JWT_AUTH,
   new JwtStrategy(jwtOptions, (jwtPayload, done) => {
-    done(null, {id: jwtPayload.id});
+    if (jwtPayload.id) {
+      done(null, {id: jwtPayload.id});
+    } else {
+      done(null, false);
+    }
   }),
 );
 
@@ -41,8 +45,12 @@ export async function jwt(ctx: Context, next: Next): Promise<void> {
   await passport.authenticate(
     JWT_AUTH,
     {session: false},
-    async (error, user) => {
-      if (error || user === false) {
+    async (error, user, info) => {
+      if (info) {
+        console.log(info);
+      }
+
+      if (error || !user.id || user === false) {
         ctx.throw(STATUS_CODES.UNAUTHORIZED, 'Invalid JWT');
       }
 


### PR DESCRIPTION
Had some weird cases when working on the bugfixes around JWT where the token could be parsed but payload had no user.id. This should catch those issues and return a 401 instead of a 500.